### PR TITLE
Making it compatible to kafka 2.5+

### DIFF
--- a/adapter/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/adapter/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -1,0 +1,9 @@
+package org.apache.kafka.clients.consumer;
+
+/**
+ * This  class is just a stub used at compile time to
+ * make compiler happy and make tobby compatible to older kafka versions
+ *
+ */
+public class ConsumerGroupMetadata {
+}

--- a/build.gradle
+++ b/build.gradle
@@ -26,18 +26,18 @@ allprojects {
     implementation("com.google.dagger:dagger:2.33")
     annotationProcessor("com.google.dagger:dagger-compiler:2.33")
 
-    compileOnly 'org.projectlombok:lombok:1.18.16'
-    annotationProcessor 'org.projectlombok:lombok:1.18.16'
+    compileOnly("org.projectlombok:lombok:1.18.16")
+    annotationProcessor("org.projectlombok:lombok:1.18.16")
 
-    implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '0.11.0.3'
+    implementation ("org.apache.kafka:kafka-clients:0.11.0.3")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
     testImplementation("org.mockito:mockito-junit-jupiter:3.7.7")
     testImplementation(project(":templates"))
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    testImplementation("ch.qos.logback:logback-classic:1.2.3")
 
-    testCompileOnly 'org.projectlombok:lombok:1.18.16'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.16'
+    testCompileOnly "org.projectlombok:lombok:1.18.16"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.16"
   }
 
   test {
@@ -63,7 +63,7 @@ release {
 
   project.ext.set("release.useAutomaticVersion", true)
   git {
-    requireBranch = 'main'
+    requireBranch = "main"
   }
   failOnCommitNeeded = false
   failOnPublishNeeded = false
@@ -81,12 +81,14 @@ confirmReleaseVersion.doLast {
 
 dependencies {
 
-  testImplementation group: 'org.flywaydb', name: 'flyway-core', version: '7.6.0'
+  compileOnly(project(":adapter"))
+
+  testImplementation group: "org.flywaydb", name: "flyway-core", version: "7.6.0"
   testImplementation("io.zonky.test:embedded-postgres:1.2.9")
   testRuntimeOnly enforcedPlatform("io.zonky.test.postgres:embedded-postgres-binaries-bom:10.4.0")
 
-  testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.2.19'
-  testImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.5.1'
-  testImplementation group: 'com.h2database', name: 'h2', version: '1.4.200'
-  testImplementation group: 'com.zaxxer', name: 'HikariCP', version: '4.0.3'
+  testImplementation group: "org.postgresql", name: "postgresql", version: "42.2.19"
+  testImplementation group: "org.hsqldb", name: "hsqldb", version: "2.5.1"
+  testImplementation group: "com.h2database", name: "h2", version: "1.4.200"
+  testImplementation group: "com.zaxxer", name: "HikariCP", version: "4.0.3"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,3 +3,4 @@ rootProject.name = "tobby-transactional-outbox"
 include 'jdbi'
 include 'spring'
 include 'templates'
+include 'adapter'

--- a/spring/src/test/java/com/mageddo/tobby/producer/spring/ProducerSpringTest.java
+++ b/spring/src/test/java/com/mageddo/tobby/producer/spring/ProducerSpringTest.java
@@ -1,5 +1,11 @@
 package com.mageddo.tobby.producer.spring;
 
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.UUID;
+
 import com.mageddo.tobby.ProducerRecord;
 import com.mageddo.tobby.producer.Producer;
 
@@ -16,18 +22,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import templates.ProducerRecordTemplates;
 
-import java.sql.Connection;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.UUID;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/src/main/java/com/mageddo/tobby/internal/utils/SyncFuture.java
+++ b/src/main/java/com/mageddo/tobby/internal/utils/SyncFuture.java
@@ -1,0 +1,38 @@
+package com.mageddo.tobby.internal.utils;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class SyncFuture<V> implements Future<V> {
+
+  private final V value;
+
+  public SyncFuture(V value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    return false;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return false;
+  }
+
+  @Override
+  public boolean isDone() {
+    return true;
+  }
+
+  @Override
+  public V get() {
+    return this.value;
+  }
+
+  @Override
+  public V get(long timeout, TimeUnit unit) {
+    return this.value;
+  }
+}

--- a/src/main/java/com/mageddo/tobby/producer/kafka/JdbcKafkaProducerAdapter.java
+++ b/src/main/java/com/mageddo/tobby/producer/kafka/JdbcKafkaProducerAdapter.java
@@ -1,10 +1,12 @@
 package com.mageddo.tobby.producer.kafka;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -59,10 +61,13 @@ public class JdbcKafkaProducerAdapter<K, V> implements Producer<K, V> {
     this.kafkaDelegate.close();
   }
 
-  @Override
   public void close(long timeout, TimeUnit unit) {
     this.jdbcDelegate.close(timeout, unit);
     this.kafkaDelegate.close(timeout, unit);
+  }
+
+  public void close(Duration timeout) {
+    this.close(timeout.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override
@@ -80,6 +85,11 @@ public class JdbcKafkaProducerAdapter<K, V> implements Producer<K, V> {
       Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId
   ) {
     this.jdbcDelegate.initTransactions();
+  }
+
+  public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata)
+      throws ProducerFencedException {
+    this.jdbcDelegate.sendOffsetsToTransaction(offsets, groupMetadata);
   }
 
   @Override

--- a/src/main/java/com/mageddo/tobby/producer/kafka/SimpleJdbcKafkaProducerAdapter.java
+++ b/src/main/java/com/mageddo/tobby/producer/kafka/SimpleJdbcKafkaProducerAdapter.java
@@ -1,5 +1,6 @@
 package com.mageddo.tobby.producer.kafka;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -7,8 +8,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import com.mageddo.tobby.producer.ProducerJdbc;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
@@ -67,6 +66,12 @@ public class SimpleJdbcKafkaProducerAdapter<K, V> implements Producer<K, V> {
     this.transactionUnsupportedError();
   }
 
+  public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+      org.apache.kafka.clients.consumer.ConsumerGroupMetadata groupMetadata)
+      throws ProducerFencedException {
+    this.transactionUnsupportedError();
+  }
+
   @Override
   public void commitTransaction() throws ProducerFencedException {
     this.transactionUnsupportedError();
@@ -112,7 +117,6 @@ public class SimpleJdbcKafkaProducerAdapter<K, V> implements Producer<K, V> {
     this.executorService.shutdown();
   }
 
-  @Override
   public void close(long timeout, TimeUnit unit) {
     try {
       this.executorService.shutdown();
@@ -120,6 +124,10 @@ public class SimpleJdbcKafkaProducerAdapter<K, V> implements Producer<K, V> {
     } catch (InterruptedException e) {
       this.executorService.shutdownNow();
     }
+  }
+
+  public void close(Duration timeout) {
+    this.close(timeout.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   private void transactionUnsupportedError() {

--- a/src/test/java/com/mageddo/tobby/producer/kafka/SimpleJdbcKafkaProducerAdapterTest.java
+++ b/src/test/java/com/mageddo/tobby/producer/kafka/SimpleJdbcKafkaProducerAdapterTest.java
@@ -1,5 +1,6 @@
 package com.mageddo.tobby.producer.kafka;
 
+import java.time.Duration;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -103,5 +104,17 @@ class SimpleJdbcKafkaProducerAdapterTest {
     assertTrue(this.producer.executorService.isShutdown());
     assertTrue(this.producer.executorService.isTerminated());
 
+  }
+
+  @Test
+  void mustCloseUsingDurationMethodSignature(){
+    // arrange
+
+    // act
+    this.producer.close(Duration.ofSeconds(2));
+
+    // assert
+    assertTrue(this.producer.executorService.isShutdown());
+    assertTrue(this.producer.executorService.isTerminated());
   }
 }

--- a/src/test/java/com/mageddo/tobby/producer/kafka/SimpleJdbcKafkaProducerAdapterTest.java
+++ b/src/test/java/com/mageddo/tobby/producer/kafka/SimpleJdbcKafkaProducerAdapterTest.java
@@ -13,11 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import templates.KafkaProducerRecordTemplates;
 import templates.RecordMetadataTemplates;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
@@ -74,12 +75,13 @@ class SimpleJdbcKafkaProducerAdapterTest {
     // assert
     final RecordMetadata metadata = future.get();
     assertEquals("fruit-1@-1", metadata.toString());
-    assertEquals("fruit-1@-1", callbackMetadata.get().toString());
+    assertEquals("fruit-1@-1", callbackMetadata.get()
+        .toString());
 
   }
 
   @Test
-  void mustClose(){
+  void mustClose() {
 
     // arrange
 
@@ -87,13 +89,12 @@ class SimpleJdbcKafkaProducerAdapterTest {
     this.producer.close();
 
     // assert
-    assertTrue(this.producer.executorService.isShutdown());
-    assertTrue(this.producer.executorService.isTerminated());
+
 
   }
 
   @Test
-  void mustCloseWithTimeout(){
+  void mustCloseWithTimeout() {
 
     // arrange
 
@@ -101,20 +102,40 @@ class SimpleJdbcKafkaProducerAdapterTest {
     this.producer.close(3, TimeUnit.SECONDS);
 
     // assert
-    assertTrue(this.producer.executorService.isShutdown());
-    assertTrue(this.producer.executorService.isTerminated());
+
 
   }
 
   @Test
-  void mustCloseUsingDurationMethodSignature(){
+  void mustCloseUsingDurationMethodSignature() {
     // arrange
 
     // act
     this.producer.close(Duration.ofSeconds(2));
 
     // assert
-    assertTrue(this.producer.executorService.isShutdown());
-    assertTrue(this.producer.executorService.isTerminated());
+
+  }
+
+  @Test
+  void mustSendAndExecuteCallbackSynchronouslyAndNotAbortWhenCallbackFails() throws Exception {
+    // arrange
+
+    doReturn(RecordMetadataTemplates.build())
+        .when(this.jdbcKafkaProducer)
+        .send(any());
+
+    final var record = KafkaProducerRecordTemplates.mango();
+
+    // act
+    final var metadata = this.producer
+        .send(record, (m, exception) -> {
+          throw new IllegalStateException("Oops");
+        })
+        .get();
+
+    // assert
+    assertNotNull(metadata);
+    assertEquals("fruit", metadata.topic());
   }
 }

--- a/templates/src/main/java/templates/KafkaProducerRecordTemplates.java
+++ b/templates/src/main/java/templates/KafkaProducerRecordTemplates.java
@@ -15,4 +15,8 @@ public class KafkaProducerRecordTemplates {
         List.of(new RecordHeader("version", "1".getBytes()))
     );
   }
+
+  public static ProducerRecord<String, String> mango() {
+    return new ProducerRecord<>("fruit", "Mango");
+  }
 }


### PR DESCRIPTION
## Changelog
* Making Tobby compatible to kafka clients 2.5+
* Removing the requirement of background threads

